### PR TITLE
Support no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urlencoding"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Bertram Truong <b@bertramtruong.com>"]
 license = "MIT"
 description = "A Rust library for doing URL percentage encoding."
@@ -8,3 +8,7 @@ repository = "https://github.com/bt/rust_urlencoding"
 keywords = ["url", "encoding", "urlencoding"]
 
 [dependencies]
+
+[features]
+default = ["use_std"]
+use_std = []

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Installation
 This crate can be downloaded through Cargo. To do so, add the following line to your `Cargo.toml` file, under `dependencies`:
 
 ```toml
-urlencoding = "1.0.0"
+urlencoding = "1.0.1"
 ```
 
 Usage
@@ -42,6 +42,12 @@ fn main() {
   println!("{}", decoded.unwrap());
   // 👾 Exterminate!
 }
+```
+
+To use it in `no_std` environment, do the following in Cargo.toml:
+
+```
+urlencoding = { version = "1.0.1", default-features = false }
 ```
 
 License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,19 @@
+#![cfg_attr(not(feature = "use_std"), no_std)]
+#![cfg_attr(not(feature = "use_std"), feature(alloc))]
+
+#[cfg(not(feature = "use_std"))]
+#[macro_use]
+extern crate alloc as std;
+
+#[cfg(not(feature = "use_std"))]
+use std::prelude::*;
+
 use std::str;
 use std::string::FromUtf8Error;
-use std::error::Error;
+#[cfg(feature = "use_std")]
 use std::fmt::{self, Display};
+#[cfg(feature = "use_std")]
+use std::error::Error;
 
 pub fn encode(data: &str) -> String {
     let mut escaped = String::new();
@@ -85,6 +97,7 @@ pub enum FromUrlEncodingError {
     Utf8CharacterError { error: FromUtf8Error },
 }
 
+#[cfg(feature = "use_std")]
 impl Error for FromUrlEncodingError {
     fn description(&self) -> &str {
         match self {
@@ -101,6 +114,7 @@ impl Error for FromUrlEncodingError {
     }
 }
 
+#[cfg(feature = "use_std")]
 impl Display for FromUrlEncodingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self {


### PR DESCRIPTION
Hi there,

This crate is pretty neat and good for `no_std` environments. This is the patch. I've been using it in my [rust-sgx-sdk](https://github.com/baidu/rust-sgx-sdk) using this with `no_std` support. Thanks!

Best,
Yu

Signed-off-by: Yu Ding <dingelish@gmail.com>