### PR TITLE
WHATWG URL spec conformance, optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "urlencoding"
 version = "1.0.0"
-authors = ["Bertram Truong <b@bertramtruong.com>"]
+authors = ["Bertram Truong <b@bertramtruong.com>", "Kornel <kornel@geekhood.net>"]
 license = "MIT"
 description = "A Rust library for doing URL percentage encoding."
 repository = "https://github.com/bt/rust_urlencoding"
 keywords = ["url", "encoding", "urlencoding"]
+edition = "2018"
+categories = ["encoding", "web-programming"]
 
-[dependencies]


### PR DESCRIPTION
It's more than two times faster, and conforms to [the URL standard](https://url.spec.whatwg.org/#percent-decode).

```diff
 name          old ns/iter  new ns/iter  diff ns/iter   diff %  speedup
+bench_decode  4,592        1,850              -2,742  -59.71%   x 2.48
+bench_encode  14,068       5,192              -8,876  -63.09%   x 2.71
```

Includes #6 and #7